### PR TITLE
Drop support for python 3.4 and 3.5, bump version to 2.2.4

### DIFF
--- a/anyblok_marshmallow/release.py
+++ b/anyblok_marshmallow/release.py
@@ -9,4 +9,4 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-version = '2.2.3'
+version = '2.2.4'

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -13,26 +13,32 @@
 CHANGELOG
 =========
 
+2.2.4 (2019-09-09)
+------------------
+
+* Fix Marshmallow dependency to 3.0.3 release
+* Drop support for python 3.4 and 3.5
+
 2.2.3 (2019-05-06)
 ------------------
 
-* Fixed du of Marshmallow 3.0.0RC5 release
+* Fix Marshmallow dependency to 3.0.0RC5 release
 * Refactored unittest from nosetest to pytest
 
 2.2.2 (2018-12-06)
 ------------------
 
-* Fixed du of Marshmallow 3.0.0RC1 release
+* Fix Marshmallow dependency to 3.0.0RC1 release
 
 2.2.1 (2018-10-26)
 ------------------
 
-* Fixed du of Marshmallow 3.0.0b19 release
+* Fix Marshmallow dependency to 3.0.0b19 release
 
 2.2.0 (2018-10-17)
 ------------------
 
-* Fixed the convertion of type between **AnyBlok.Column** and **marshmallow.Field**
+* Fixed the conversion of type between **AnyBlok.Column** and **marshmallow.Field**
 
 2.1.0 (2018-09-26)
 ------------------

--- a/doc/FRONT.rst
+++ b/doc/FRONT.rst
@@ -59,9 +59,9 @@ Run the test with ``nose``::
 Dependencies
 ------------
 
-AnyBlok works with **Python 3.3** and later. The install process will
+AnyBlok works with **Python 3.6** and later. The install process will
 ensure that `AnyBlok <http://doc.anyblok.org>`_,
-`marshmallow >= 3.0.0 <https://marshmallow.readthedocs.io/en/latest/>`_ and 
+`marshmallow >= 3.0.3 <https://marshmallow.readthedocs.io/en/latest/>`_ and 
 `marshmallow-sqlalchemy <https://marshmallow-sqlalchemy.readthedocs.io/en/latest/>`_ 
 are installed, in addition to other dependencies. 
 The latest version of them is strongly recommended.

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,6 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open(
 
 requirements = [
     'anyblok',
-    'marshmallow==3.0.0rc5',
+    'marshmallow==3.0.3',
     'marshmallow-sqlalchemy',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup, find_packages
 from os.path import abspath, dirname, join
 
 
-version = "2.2.3"
+version = "2.2.4"
 here = abspath(dirname(__file__))
 
 with open(join(here, 'README.rst'), 'r',


### PR DESCRIPTION
Marshmallow_sqlalchemy has just drop support for python 3.4 / 3.5 (https://github.com/marshmallow-code/marshmallow-sqlalchemy/commit/12eb13838fe3bce2b24ee79a78629b0f12b975e5)

Follow it and set a new 2.2.4 version.
Please also note that we finally do not live with dependency to marshmallow release candidate version now that we depend on 3.0.3, that's a pretty good news!