### PR TITLE
Improved Country Field

### DIFF
--- a/anyblok_marshmallow/fields.py
+++ b/anyblok_marshmallow/fields.py
@@ -1,6 +1,7 @@
 # This file is a part of the AnyBlok / Marshmallow api project
 #
 #    Copyright (C) 2017 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
+#    Copyright (C) 2017 Alexis Tourneux <alexis.tourneux@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can

--- a/anyblok_marshmallow/fields.py
+++ b/anyblok_marshmallow/fields.py
@@ -232,19 +232,7 @@ class Country(String):
     def _serialize(self, value, attr, obj):
 
         if value is not None and not isinstance(value, str):
-
-            if self.dump_mode == 'alpha_3':
-                return value.alpha_3
-            elif self.dump_mode == 'alpha_2':
-                return value.alpha_2
-            elif self.dump_mode == 'numeric':
-                return value.numeric
-            elif self.dump_mode == 'name':
-                return value.name
-            elif self.dump_mode == 'official_name':
-                return value.official_name
-
-        return value
+            return getattr(value, self.dump_mode) or value
 
     def _deserialize(self, value, attr, data, **kwargs):
 

--- a/anyblok_marshmallow/fields.py
+++ b/anyblok_marshmallow/fields.py
@@ -1,7 +1,7 @@
 # This file is a part of the AnyBlok / Marshmallow api project
 #
 #    Copyright (C) 2017 Jean-Sebastien SUZANNE <jssuzanne@anybox.fr>
-#    Copyright (C) 2017 Alexis Tourneux <alexis.tourneux@gmail.com>
+#    Copyright (C) 2019 Alexis Tourneux <alexis.tourneux@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can

--- a/anyblok_marshmallow/tests/test_fields.py
+++ b/anyblok_marshmallow/tests/test_fields.py
@@ -1582,7 +1582,6 @@ class TestFieldCountry:
         class ExampleCountrySchema(Schema):
             country = fields.Country(mode=fields.Country.Modes.ALPHA_2)
 
-
         sch = ExampleCountrySchema()
 
         country = sch.load(dict(country='FR'))
@@ -1605,7 +1604,6 @@ class TestFieldCountry:
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
             country = fields.Country(mode=fields.Country.Modes.NUMERIC)
-
 
         sch = ExampleCountrySchema()
 
@@ -1630,7 +1628,6 @@ class TestFieldCountry:
         class ExampleCountrySchema(Schema):
             country = fields.Country(mode=fields.Country.Modes.NAME)
 
-
         sch = ExampleCountrySchema()
 
         country = sch.load(dict(country='France'))
@@ -1653,7 +1650,6 @@ class TestFieldCountry:
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
             country = fields.Country(mode=fields.Country.Modes.OFFICIAL_NAME)
-
 
         sch = ExampleCountrySchema()
 
@@ -1694,7 +1690,6 @@ class TestFieldCountry:
                     dump_mode=fields.Country.Modes.ALPHA_2
                     )
 
-
         sch = ExampleCountrySchema()
 
         country = sch.load(dict(country='FRA'))
@@ -1704,6 +1699,7 @@ class TestFieldCountry:
         assert country == {
                 'country': 'FR'
                 }
+
 
 def add_field_color():
 

--- a/anyblok_marshmallow/tests/test_fields.py
+++ b/anyblok_marshmallow/tests/test_fields.py
@@ -1576,6 +1576,127 @@ class TestFieldCountry:
             {'country': ['Not a valid country.']}
         )
 
+    def test_country_alpha_2_mode(self):
+
+        # Define some schema to test Country Field configuration
+        class ExampleCountrySchema(Schema):
+            country = fields.Country(mode='alpha_2')
+
+
+        sch = ExampleCountrySchema()
+
+        country = sch.load(dict(country='FR'))
+
+        assert isinstance(
+                country.get('country'), type(
+                    pycountry.countries.get(alpha_3='FRA')))
+        assert country.get('country') == pycountry.countries.get(
+                alpha_3='FRA')
+
+        country = sch.dump(country)
+
+        assert isinstance(country, dict)
+        assert country == {
+                'country': 'FR'
+                }
+
+    def test_country_numeric_mode(self):
+
+        # Define some schema to test Country Field configuration
+        class ExampleCountrySchema(Schema):
+            country = fields.Country(mode="numeric")
+
+
+        sch = ExampleCountrySchema()
+
+        country = sch.load(dict(country='250'))
+
+        assert isinstance(
+                country.get('country'), type(
+                    pycountry.countries.get(alpha_3='FRA')))
+        assert country.get('country') == pycountry.countries.get(
+                alpha_3='FRA')
+
+        country = sch.dump(country)
+
+        assert isinstance(country, dict)
+        assert country == {
+                'country': '250'
+                }
+
+    def test_country_name_mode(self):
+
+        # Define some schema to test Country Field configuration
+        class ExampleCountrySchema(Schema):
+            country = fields.Country(mode="name")
+
+
+        sch = ExampleCountrySchema()
+
+        country = sch.load(dict(country='France'))
+
+        assert isinstance(
+                country.get('country'), type(
+                    pycountry.countries.get(alpha_3='FRA')))
+        assert country.get('country') == pycountry.countries.get(
+                alpha_3='FRA')
+
+        country = sch.dump(country)
+
+        assert isinstance(country, dict)
+        assert country == {
+                'country': 'France'
+                }
+
+    def test_country_official_name_mode(self):
+
+        # Define some schema to test Country Field configuration
+        class ExampleCountrySchema(Schema):
+            country = fields.Country(mode="official_name")
+
+
+        sch = ExampleCountrySchema()
+
+        country = sch.load(dict(country='French Republic'))
+
+        assert isinstance(
+                country.get('country'), type(
+                    pycountry.countries.get(alpha_3='FRA')))
+        assert country.get('country') == pycountry.countries.get(
+                alpha_3='FRA')
+
+        country = sch.dump(country)
+
+        assert isinstance(country, dict)
+        assert country == {
+                'country': 'French Republic'
+                }
+
+    def test_country_unknown_mode(self):
+
+        with pytest.raises(ValueError) as exception:
+            # Define some schema to test Country Field configuration
+            class ExampleCountrySchema(Schema):
+                country = fields.Country(mode="not_a_valid_mode")
+
+        assert str(fields.Country.ALLOWED_MODES) in str(exception.value)
+
+    def test_country_different_load_and_dump_mode(self):
+
+        # Define some schema to test Country Field configuration
+        class ExampleCountrySchema(Schema):
+            country = fields.Country(load_mode="alpha_3", dump_mode="alpha_2")
+
+
+        sch = ExampleCountrySchema()
+
+        country = sch.load(dict(country='FRA'))
+        assert country.get('country') == pycountry.countries.get(alpha_3='FRA')
+
+        country = sch.dump(country)
+        assert country == {
+                'country': 'FR'
+                }
 
 def add_field_color():
 

--- a/anyblok_marshmallow/tests/test_fields.py
+++ b/anyblok_marshmallow/tests/test_fields.py
@@ -1580,7 +1580,7 @@ class TestFieldCountry:
 
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
-            country = fields.Country(mode='alpha_2')
+            country = fields.Country(mode=fields.Country.Modes.ALPHA_2)
 
 
         sch = ExampleCountrySchema()
@@ -1604,7 +1604,7 @@ class TestFieldCountry:
 
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
-            country = fields.Country(mode="numeric")
+            country = fields.Country(mode=fields.Country.Modes.NUMERIC)
 
 
         sch = ExampleCountrySchema()
@@ -1628,7 +1628,7 @@ class TestFieldCountry:
 
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
-            country = fields.Country(mode="name")
+            country = fields.Country(mode=fields.Country.Modes.NAME)
 
 
         sch = ExampleCountrySchema()
@@ -1652,7 +1652,7 @@ class TestFieldCountry:
 
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
-            country = fields.Country(mode="official_name")
+            country = fields.Country(mode=fields.Country.Modes.OFFICIAL_NAME)
 
 
         sch = ExampleCountrySchema()
@@ -1679,13 +1679,20 @@ class TestFieldCountry:
             class ExampleCountrySchema(Schema):
                 country = fields.Country(mode="not_a_valid_mode")
 
-        assert str(fields.Country.ALLOWED_MODES) in str(exception.value)
+        assert str(
+                list(
+                    fields.Country.Modes.__members__.keys()
+                    )
+                ) in str(exception.value)
 
     def test_country_different_load_and_dump_mode(self):
 
         # Define some schema to test Country Field configuration
         class ExampleCountrySchema(Schema):
-            country = fields.Country(load_mode="alpha_3", dump_mode="alpha_2")
+            country = fields.Country(
+                    load_mode=fields.Country.Modes.ALPHA_3,
+                    dump_mode=fields.Country.Modes.ALPHA_2
+                    )
 
 
         sch = ExampleCountrySchema()

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -13,6 +13,12 @@
 CHANGELOG
 =========
 
+2.3.1 (Unreleased)
+------------------
+
+* Improved Country field to add parametrization. Allowed modes are alpha 3, alpha 2,
+  numeric, name and official name.
+
 2.3.0 (2019-10-31)
 ------------------
 


### PR DESCRIPTION
**Context :**

I was using Country field in a standard Marshmallow schema for validating input form data. Among the input data was a field country that I would have represented on interface using one of country field for vue provided by a vueJS library.

However, when validating the input with the Country field, I figured out that only alpha 3 inputs were correctly handled. Unfortunaltely much of vueJS fields were provided country data in alpha 2 format.

**Fix Proposal :**

Add some way to configure mode parameters for serialization/deserialization.

- Created a Modes enum in fields.Country.Modes with the different modes, which are the ones available in a pycountry object instance : 

    * Alpha 3 (Country.Modes.ALPHA_3)
    * Alpha 2 (Country.Modes.ALPHA_2)
    * Numeric Code (Country.Modes.NUMERIC)
    * Name (Country.Modes.NAME)
    * Official Name (Country.Modes.OFFICIAL_NAME)


- Created parameters for field initialization : 

    * mode (defaults to None) -> if set, both serialization and deserialization mode are set to this value
    * load_mode (defaults to Country.Modes.ALPHA_3) -> if mode is not set, deserialization is made using that mode
    * dump_mode (defaults to Country.Modes.ALPHA_3) -> if mode is not set, serialization is made using that mode